### PR TITLE
Disable focusing search box using hotkeys

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,7 +2,11 @@ module.exports = {
   title: 'Paul Copplestone',
   description: 'Techie and entrepreneur',
   dest: 'public',
-  plugins: ['@vuepress/last-updated', ['@vuepress/google-analytics', { ga: 'UA-93673521-3' }]],
+  plugins: [
+    '@vuepress/last-updated',
+    ['@vuepress/google-analytics', { ga: 'UA-93673521-3' }],
+    ['@vuepress/search', { searchHotkeys: [] }],
+  ],
   // head: [
   //   [
   //     'link',


### PR DESCRIPTION
**Problem:**
As noted in [the Hacker News thread](https://news.ycombinator.com/item?id=22130692), the 's' key is hijacked by VuePress in order to focus the search box.

**Solution:**
As outlined in [the VuePress search plugin docs](https://vuepress.vuejs.org/plugin/official/plugin-search.html#searchhotkeys), passing an empty array to the `searchHotkeys` option disables all hotkeys.