### PR TITLE
Update Supabase domain name from .io to .com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@
 
 ## Startups
 
-[Supabase](https://supabase.io) - Co-Founder & CEO<br />
+[Supabase](https://supabase.com) - Co-Founder & CEO<br />
 The open source Firebase alternative.
 
 [Nimbus For Work](https://nimbusforwork.com) - Co-Founder & CTO<br />


### PR DESCRIPTION
This pull request is for updating the link for Supabase under the `startups` section, from `supabase.io` to `supabase.com`.