### PR TITLE
Fix typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 [Blog](/blog/) <br />General writing and opinions.
 
-[Knowledge](/knowledge/) <br />Personal zettlekasten.
+[Knowledge](/knowledge/) <br />Personal zettelkasten.
 
 **Find me online** <br />[Twitter](https://twitter.com/kiwicopple) | [GitHub](https://github.com/kiwicopple) | [LinkedIn](https://www.linkedin.com/in/paulcopplestone/)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 [Blog](/blog/) <br />General writing and opinions.
 
-[Knowledge](/knowledge/) <br />Personal zettelkasten.
+[Knowledge](/knowledge/) <br />Personal Zettelkasten.
 
 **Find me online** <br />[Twitter](https://twitter.com/kiwicopple) | [GitHub](https://github.com/kiwicopple) | [LinkedIn](https://www.linkedin.com/in/paulcopplestone/)
 


### PR DESCRIPTION
Hi again @kiwicopple, hope you're well!

Just a quick PR to fix the typo on the German word "Zettelkasten"

One more detail is that nouns are capitalized in German, so it could actually be "Personal Zettelkasten." if you wanted it to be full German-style - but this PR doesn't make that additional change