### PR TITLE
Removes roadtoscale from startup resources

### DIFF
--- a/docs/knowledge/business/resources.md
+++ b/docs/knowledge/business/resources.md
@@ -2,7 +2,6 @@
 
 - [incubatorlist.com](https://incubatorlist.com/) - A curated list of 250 startup incubators and accelerators
 - [Software pricing guide](https://news.ycombinator.com/item?id=22027912)
-- [A curated knowledge library for every stage of your startup journey](https://roadtoscale.com/)
 - [Remote Work Tools](https://nohq.co/tools/)
 - [How to Kill a Startup Idea with Google Keyword Planner and AdWords: A Case Study](https://hn.premii.com/#/comments/22110004)
 - Startup Idea Checklist - https://hn.premii.com/#/comments/20254057


### PR DESCRIPTION
The URL https://roadtoscale.com/ now leads to some kind of online casino and is no longer reachable. I recommend it's removal as it is no longer useful. Sadly the content is not archived on the waybackmachine either (see https://web.archive.org/web/20201102123042/https://roadtoscale.com/).