### PR TITLE
Add Netlify configuration for build and deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = "npm run build"
+  publish = "public"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/404.html"
+  status = 404


### PR DESCRIPTION
## Summary
This PR adds a `netlify.toml` configuration file to set up Netlify build and deployment settings for the project.

## Key Changes
- **Build configuration**: Specifies `npm run build` as the build command and `public` as the publish directory
- **Node.js version**: Pins Node.js to version 20 for consistent build environments
- **404 redirect rule**: Configures a catch-all redirect that routes all unmatched paths to `/404.html` with a 404 status code

## Implementation Details
The configuration enables proper deployment on Netlify with:
- Explicit build command and output directory for the CI/CD pipeline
- Fixed Node.js version to prevent build inconsistencies across different deployment environments
- Client-side routing support via the 404 redirect, which is useful for single-page applications (SPAs) that handle routing in the browser

https://claude.ai/code/session_01NFKR9eYV8WU9UgHwAD1r9t